### PR TITLE
Use TargetFrameworkIdentifier build property to detect .NET Framework targets

### DIFF
--- a/build/NetFX.targets
+++ b/build/NetFX.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- .NET Framework targeting (required to allow compilation against .NET Framework in non-Windows environments) -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net481' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'net47' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This PR modifies `NetFX.targets` to use the `TargetFrameworkIdentifier` build property to detect .NET Framework targets, instead of looking for specific .NET Framework target versions.