### PR TITLE
Visual Studio extensions and build updates

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "components": [],
+    "extensions": [
+        "https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WorkflowBrowser",
+        "https://marketplace.visualstudio.com/items?itemName=MadsKristensen.MarkdownEditor2"
+    ]
+}

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,20 +13,12 @@
   </PropertyGroup>
 
   <!-- SourceLink settings -->
-  <PropertyGroup Condition=" '$(DisableSourceLink)' != 'true' ">
+  <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
-  <!-- SourceLink package reference -->
-  <ItemGroup Condition=" '$(DisableSourceLink)' != 'true' "> 
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <!-- .NET Framework targeting support (required to allow compilation against .NET Framework in 
        non-Windows environments). -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,16 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
   
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
   </ItemGroup>
   
 </Project>

--- a/README.md
+++ b/README.md
@@ -14,34 +14,6 @@ Repository template for a C# project.
 - Create example projects that demonstrate the library and application projects in the `samples` folder.
 
 
-# Repository Structure
-
-The repository is organised as follows:
-
-- `[root]`
-  - `.editorconfig` - Code style rules (see [here](https://editorconfig.org/) for details).
-  - `.gitattributes`
-  - `.gitignore`
-  - `build.cake` - [Cake](https://cakebuild.net/) script for building the projects.
-  - `build.ps1` - PowerShell script to bootstrap and run the Cake script.
-  - `build.sh` - Bash shell script to bootstrap and run the Cake script.
-  - `Directory.Build.props` - Common MSBuild properties and targets (see [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build) for details).
-  - `Directory.Build.targets` - Common MSBuild properties and targets (see [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build) for details). 
-  - `Directory.Packages.props` - Common NuGet package versions (see [here](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) for details). 
-  - `LICENSE` - Licence details.
-  - `README.md`
-  - `RENAME-ME.sln` - Visual Studio solution file.
-  - `[build]` - Resources for building the solution.
-    - `Copyright.props` - Sets the copyright message for all projects in the solution.
-    - `NetFX.targets` - Adds package references for building projects that target .NET Framework on non-Windows systems.
-    - `version.json` - Defines version numbers used when building the projects.
-  - `[samples]` - Example projects to demonstrate the usage of the repository libraries and applications.
-    - `Directory.Build.props` - Common MSBuild properties and targets related to example projects (see [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build) for details).
-  - `[src]` - Source code for repository libraries and applications.
-  - `[test]` - Test and benchmarking projects.
-    - `Directory.Build.props` - Common MSBuild properties and targets related to test projects (see [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build) for details).
-
-
 # Building the Solution
 
 The repository uses [Cake](https://cakebuild.net/) for cross-platform build automation. The build script allows for metadata such as a build counter to be specified when called by a continuous integration system such as TeamCity.

--- a/RENAME-ME.sln
+++ b/RENAME-ME.sln
@@ -4,25 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.1.32407.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{10A2813D-C970-4F6F-9A59-94F7C972257F}"
-	ProjectSection(SolutionItems) = preProject
-		src\README.md = src\README.md
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{C4C50D71-6AAC-45A9-9257-5D02A42B61DC}"
 	ProjectSection(SolutionItems) = preProject
-		build\Copyright.props = build\Copyright.props
-		build\NetFX.targets = build\NetFX.targets
-		build\README.md = build\README.md
 		build\version.json = build\version.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{0390FA5C-0123-44B7-A7E9-794A9582CD41}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		build.cake = build.cake
-		build.ps1 = build.ps1
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
@@ -31,16 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{0390FA
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{ADFADB4B-0729-40E6-B241-6E1B89A8731C}"
-	ProjectSection(SolutionItems) = preProject
-		test\Directory.Build.props = test\Directory.Build.props
-		test\README.md = test\README.md
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{9EC81ADF-5CE2-4140-96BC-958CB9E0365C}"
-	ProjectSection(SolutionItems) = preProject
-		samples\Directory.Build.props = samples\Directory.Build.props
-		samples\README.md = samples\README.md
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionProperties) = preSolution

--- a/build.cake
+++ b/build.cake
@@ -44,6 +44,18 @@ const string VersionFile = "./build/version.json";
 //   Additional build metadata that will be included in the informational version number generated 
 //   for compiled assemblies.
 //
+// --container-registry=<REGISTRY>
+//   The container registry to use when the PublishContainer target is specified.
+//     Default: Local Docker or Podman daemon
+//
+// --container-os=<OS>
+//   The container operating system to use when the PublishContainer target is specified.
+//     Default: linux
+//
+// --container-arch=<ARCHITECTURE>
+//   The container processor architecture to use when the PublishContainer target is specified.
+//     Default: x64
+//
 // --property=<PROPERTY>
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
 //   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This 
@@ -61,7 +73,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=2.0.2
+#load nuget:?package=Jaahas.Cake.Extensions&version=2.1.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 0,
   "Minor": 1,
   "Patch": 0,
-  "PreRelease": "alpha"
+  "PreRelease": "pre"
 }

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SignOutput>false</SignOutput>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <DisableSourceLink>true</DisableSourceLink>
   </PropertyGroup>
   
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SignOutput>false</SignOutput>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <DisableSourceLink>true</DisableSourceLink>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR modifies the template to include a `.vsconfig` file that will prompt the user to install recommended extensions when opening the solution in Visual Studio.

It also contains updates to Cake build scripts and the default VS solution structure.