### PR TITLE
Spring cleaning

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,8 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
-      "commands": [
-        "dotnet-cake"
-      ]
+      "version": "5.0.0",
+      "commands": ["dotnet-cake"]
     }
   }
 }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,13 +1,12 @@
 <Project>
-  
+
   <!-- Recursively import the Directory.Build.targets file from the parent folder if it exists. -->
   <PropertyGroup>
     <ParentProject>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</ParentProject>
   </PropertyGroup>
   <Import Project="$(ParentProject)" Condition=" '$(ParentProject)' != '' " />
 
-  <!-- Enable .NET code analyzers for projects targeting earlier than .NET 5.0 (requires .NET 5.0 
-       SDK or later to be installed). -->
+  <!-- Enable .NET code analyzers for projects targeting earlier than .NET 5.0 -->
   <PropertyGroup>
     <AnalysisMode Condition=" '$(AnalysisMode)' == '' ">Default</AnalysisMode>
   </PropertyGroup>
@@ -20,7 +19,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <!-- .NET Framework targeting support (required to allow compilation against .NET Framework in 
+  <!-- .NET Framework targeting support (required to allow compilation against .NET Framework in
        non-Windows environments). -->
   <Import Project=".\build\NetFX.targets" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,12 +9,10 @@
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageVersion Include="MSTest" Version="3.8.2" />
   </ItemGroup>
-  
+
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -9,39 +9,39 @@ const string VersionFile = "./build/version.json";
 // COMMAND LINE ARGUMENTS:
 //
 // --project=<PROJECT OR SOLUTION>
-//   The MSBuild project or solution to build. 
+//   The MSBuild project or solution to build.
 //     Default: see DefaultSolutionFile constant above.
 //
 // --target=<TARGET>
-//   The Cake target to run. 
+//   The Cake target to run.
 //     Default: Test
 //     Possible Values: Clean, Restore, Build, Test, Pack, BillOfMaterials
 //
 // --configuration=<CONFIGURATION>
-//   The MSBuild configuration to use. 
+//   The MSBuild configuration to use.
 //     Default: Debug
 //
 // --clean
-//   Specifies that this is a rebuild rather than an incremental build. All artifact, bin, and test 
+//   Specifies that this is a rebuild rather than an incremental build. All artifact, bin, and test
 //   output folders will be cleaned prior to running the specified target.
 //
 // --no-tests
-//   Specifies that unit tests should be skipped, even if a target that depends on the Test target 
+//   Specifies that unit tests should be skipped, even if a target that depends on the Test target
 //   is specified.
 //
 // --ci
-//   Forces continuous integration build mode. Not required if the build is being run by a 
+//   Forces continuous integration build mode. Not required if the build is being run by a
 //   supported continuous integration build system.
 //
 // --sign-output
-//   Tells MSBuild that signing is required by setting the 'SignOutput' build property to 'True'. 
+//   Tells MSBuild that signing is required by setting the 'SignOutput' build property to 'True'.
 //   The signing implementation must be supplied by MSBuild.
 //
 // --build-counter=<COUNTER>
 //   The build counter. This is used when generating version numbers for the build.
 //
 // --build-metadata=<METADATA>
-//   Additional build metadata that will be included in the informational version number generated 
+//   Additional build metadata that will be included in the informational version number generated
 //   for compiled assemblies.
 //
 // --container-registry=<REGISTRY>
@@ -54,23 +54,23 @@ const string VersionFile = "./build/version.json";
 //
 // --container-arch=<ARCHITECTURE>
 //   The container processor architecture to use when the PublishContainer target is specified.
-//     Default: x64
+//     Default: Same as host machine
 //
 // --property=<PROPERTY>
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
-//   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This 
+//   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This
 //   argument can be specified multiple times.
 //
 // --github-username=<USERNAME>
-//   Specifies the GitHub username to use when making authenticated API calls to GitHub while 
-//   running the BillOfMaterials target. You must specify the --github-token argument as well when 
+//   Specifies the GitHub username to use when making authenticated API calls to GitHub while
+//   running the BillOfMaterials target. You must specify the --github-token argument as well when
 //   specifying this argument.
 //
 // --github-token=<PERSONAL ACCESS TOKEN>
-//   Specifies the GitHub personal access token to use when making authenticated API calls to 
-//   GitHub while running the BillOfMaterials target. You must specify the --github-username 
+//   Specifies the GitHub personal access token to use when making authenticated API calls to
+//   GitHub while running the BillOfMaterials target. You must specify the --github-username
 //   argument as well when specifying this argument.
-// 
+//
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #load nuget:?package=Jaahas.Cake.Extensions&version=2.3.0


### PR DESCRIPTION
This PR makes the following changes to the repository template:

- Updates [Cake](https://cakebuild.net) to v5.0.0
- Replaces the entries for Microsoft.NET.Test.SDK, MSTest.TestAdapter and MSTest.TestFramework in Directory.Packages.props with an entry for the MSTest meta package instead.
- Tweaks to script and build file documentation.