### PR TITLE
Update .editorconfig with new naming rules and line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,13 @@
 # Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
-# Don't use tabs for indentation.
+# Defaults for all files
 [*]
+
+# Use lf for line endings.
+end_of_line = lf
+
+# Don't use tabs for indentation.
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
@@ -19,7 +24,6 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = true
 
 #### .NET Code Actions ####
@@ -225,6 +229,14 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.private_instance_fields_should_start_with_underscore.severity = suggestion
+dotnet_naming_rule.private_instance_fields_should_start_with_underscore.symbols = private_instance_fields
+dotnet_naming_rule.private_instance_fields_should_start_with_underscore.style = instance_underscored
+
+dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.severity = suggestion
+dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.style = static_underscored
+
 # Symbol specifications
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
@@ -239,6 +251,13 @@ dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, meth
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.non_field_members.required_modifiers =
 
+dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
+dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
 # Naming styles
 
 dotnet_naming_style.pascal_case.required_prefix =
@@ -250,6 +269,12 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.instance_underscored.capitalization = camel_case
+dotnet_naming_style.instance_underscored.required_prefix = _
+
+dotnet_naming_style.static_underscored.capitalization = camel_case
+dotnet_naming_style.static_underscored.required_prefix = s_
 
 
 # XML project files


### PR DESCRIPTION
Added naming rules for private instance and static fields to enforce underscore prefixes. Changed default line endings to LF and removed CRLF setting for consistency across files.