### PR TITLE
Update .editorconfig to specify private instance/static field naming conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,13 +3,8 @@
 # Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
-# Defaults for all files
-[*]
-
-# Use lf for line endings.
-end_of_line = lf
-
 # Don't use tabs for indentation.
+[*]
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
@@ -24,6 +19,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
+end_of_line = crlf
 insert_final_newline = true
 
 #### .NET Code Actions ####
@@ -229,13 +225,13 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_instance_fields_should_start_with_underscore.severity = suggestion
-dotnet_naming_rule.private_instance_fields_should_start_with_underscore.symbols = private_instance_fields
-dotnet_naming_rule.private_instance_fields_should_start_with_underscore.style = instance_underscored
+dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.severity = suggestion
+dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.symbols = private_instance_field_members
+dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.style = begins_with_underscore
 
-dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.severity = suggestion
-dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.symbols = private_static_fields
-dotnet_naming_rule.private_static_fields_should_start_with_s_underscore.style = static_underscored
+dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.severity = suggestion
+dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.symbols = private_static_field_members
+dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.style = begins_with_s_underscore
 
 # Symbol specifications
 
@@ -247,16 +243,17 @@ dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.types.required_modifiers =
 
+dotnet_naming_symbols.private_instance_field_members.applicable_kinds = field
+dotnet_naming_symbols.private_instance_field_members.applicable_accessibilities = private
+dotnet_naming_symbols.private_instance_field_members.required_modifiers =
+
+dotnet_naming_symbols.private_static_field_members.applicable_kinds = field
+dotnet_naming_symbols.private_static_field_members.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_field_members.required_modifiers = static
+
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.non_field_members.required_modifiers =
-
-dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
-dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
-
-dotnet_naming_symbols.private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_fields.required_modifiers = static
 
 # Naming styles
 
@@ -270,11 +267,15 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style.instance_underscored.capitalization = camel_case
-dotnet_naming_style.instance_underscored.required_prefix = _
+dotnet_naming_style.begins_with_underscore.required_prefix = _
+dotnet_naming_style.begins_with_underscore.required_suffix =
+dotnet_naming_style.begins_with_underscore.word_separator =
+dotnet_naming_style.begins_with_underscore.capitalization = camel_case
 
-dotnet_naming_style.static_underscored.capitalization = camel_case
-dotnet_naming_style.static_underscored.required_prefix = s_
+dotnet_naming_style.begins_with_s_underscore.required_prefix = s_
+dotnet_naming_style.begins_with_s_underscore.required_suffix =
+dotnet_naming_style.begins_with_s_underscore.word_separator =
+dotnet_naming_style.begins_with_s_underscore.capitalization = camel_case
 
 
 # XML project files


### PR DESCRIPTION
Private instance fields are camel-cased with a `_` prefix; private static fields are camel-cased with an `s_` prefix.