### PR TITLE
Editorconfig naming convention tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -225,6 +225,8 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+
+
 dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.severity = suggestion
 dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.symbols = private_instance_field_members
 dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore_prefix.style = begins_with_underscore
@@ -232,6 +234,10 @@ dotnet_naming_rule.private_instance_fields_should_be_pascal_case_with_underscore
 dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.severity = suggestion
 dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.symbols = private_static_field_members
 dotnet_naming_rule.private_static_fields_should_be_pascal_case_with_s_underscore_prefix.style = begins_with_s_underscore
+
+dotnet_naming_rule.const_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.const_members_should_be_pascal_case.symbols = const_members
+dotnet_naming_rule.const_members_should_be_pascal_case.style = pascal_case
 
 # Symbol specifications
 
@@ -246,6 +252,10 @@ dotnet_naming_symbols.types.required_modifiers =
 dotnet_naming_symbols.private_instance_field_members.applicable_kinds = field
 dotnet_naming_symbols.private_instance_field_members.applicable_accessibilities = private
 dotnet_naming_symbols.private_instance_field_members.required_modifiers =
+
+dotnet_naming_symbols.const_members.applicable_kinds = field
+dotnet_naming_symbols.const_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.const_members.required_modifiers = const
 
 dotnet_naming_symbols.private_static_field_members.applicable_kinds = field
 dotnet_naming_symbols.private_static_field_members.applicable_accessibilities = private

--- a/build.cake
+++ b/build.cake
@@ -69,7 +69,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=5.0.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=5.1.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);


### PR DESCRIPTION
Adds naming rule and symbol specification to .editorconfig to require PascalCase for const members across all accessibilities.